### PR TITLE
Update manifest to v3 which is now required by Chrome

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -1,10 +1,10 @@
 
-$.get(chrome.extension.getURL("clipboard.html"), function (html) {
+$.get(chrome.runtime.getURL("clipboard.html"), function (html) {
   $("#editprerank").prepend(html);
 
   $("#pdr_header").css(
     "background-image",
-    "url('" + chrome.extension.getURL("img/icon16.png") + "')"
+    "url('" + chrome.runtime.getURL("img/icon16.png") + "')"
   );
 
   //

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Pre-Draft Rankings for Yahoo Fantasy Sports",
   "version": "0.2.2",
   "description": "Copy and paste player names to auto-populate your pre-draft rankings for Yahoo Fantasy Sports.",
@@ -20,8 +20,13 @@
       "content.js"
     ]
   }],
-  "web_accessible_resources": [
-    "clipboard.html",
-    "img/icon16.png"
-  ]
+  "web_accessible_resources": [{
+    "resources": [
+      "clipboard.html",
+      "img/icon16.png"
+    ],
+    "matches": [
+      "*://*.fantasysports.yahoo.com/*"
+    ]
+  }]
 }


### PR DESCRIPTION
My Chrome browser wouldn't let me activate this plug-in this year and recommended I delete it. Turns out Google just started requiring a new manifest version. Pretty straightforward to update it: one renamed API function and slight change to web_accessible_resources syntax in the manifest.